### PR TITLE
Reduce target group deregistration delay to 30s for faster deploys.

### DIFF
--- a/app/runtime_service.go
+++ b/app/runtime_service.go
@@ -485,6 +485,13 @@ func (rs *RuntimeService) LazyTargetGroup(protocol application_pb.RouteProtocol,
 			Tags: sourceTags(),
 		}
 	}
+	// faster deregistration
+	a := elbv2.TargetGroup_TargetGroupAttribute{
+		Key:   String("deregistration_delay.timeout_seconds"),
+		Value: String("30"),
+	}
+	targetGroupDefinition.TargetGroupAttributes = []elbv2.TargetGroup_TargetGroupAttribute{a}
+
 	targetGroupResource := NewResource(lookupKey, targetGroupDefinition)
 	rs.TargetGroups[lookupKey] = targetGroupResource
 


### PR DESCRIPTION
We'll need to test before/after to ensure this works as expected.