### PR TITLE
role name len

### DIFF
--- a/internal/appbuilder/iam.go
+++ b/internal/appbuilder/iam.go
@@ -95,7 +95,7 @@ type StatementEntry struct {
 	Principal map[string]string `json:"Principal,omitempty"`
 }
 
-func (pb *PolicyBuilder) BuildRole(familyName string) *iam.Role {
+func (pb *PolicyBuilder) BuildRole(relativeName, familyName string) *iam.Role {
 	rolePolicies := pb.Build(familyName)
 	role := &iam.Role{
 		AssumeRolePolicyDocument: PolicyDocument{
@@ -112,9 +112,8 @@ func (pb *PolicyBuilder) BuildRole(familyName string) *iam.Role {
 		ManagedPolicyArns: pb.managedPolicyARNs,
 		Policies:          rolePolicies,
 		RoleName: cloudformation.JoinPtr("-", []string{
-			"ecs-task",
 			cloudformation.Ref("AWS::StackName"),
-			familyName,
+			relativeName,
 		}),
 	}
 	return role


### PR DESCRIPTION
There is a 64 character limit on IAM role names, this reclaims a chunk of them for use.

Original resulting role name was `ecs-task-{env_name}-{app_name}-{app_name}-{runtime_name}`. In a bit of a perfect storm of long env name, long app name, and the migration runtime for an app, you could end up with a role name that was over the 64 character limit. Looking something like `ecs-task-dev-simulated-latest-registration-registration-migration_main`.

Removing the stutter and the ecs task gains back a fair number of characters for use. Removal of `ecs-task` doesn't produce any roles that could be a collision, and only switching the construction of role name allows other things like the policy names to remain uniquely identifiable.